### PR TITLE
Additional validation of compendium source

### DIFF
--- a/module/packs.js
+++ b/module/packs.js
@@ -20,7 +20,7 @@ function getPacksByType() {
  * @returns {boolean} - Returns true if the item is from a Compendium source, false otherwise.
  */
 export function fromCompendiumSource(item) {
-	return item._stats?.compendiumSource || Boolean(/Compendium/.exec(item.flags.core?.sourceId));
+	return (item._stats?.compendiumSource && fromUuidSync(item._stats?.compendiumSource).constructor.name == "Compendium") || Boolean(/Compendium/.exec(item.flags.core?.sourceId));
 }
 
 /**


### PR DESCRIPTION
This may have a Foundry VTT bug as a root cause, but the additional validation shouldn't hurt even if the root cause is addressed.

If an Item is dragged from an Actor to another Actor, the item._stats?.compendiumSource property is populated with a reference to the original item, which makes fromCompendiumSource() return true incorrectly. This means that items dragged from one actor to another are treated as linked and cannot be modified, but because the rest of the code assumes there is a compendium involved, otherwise results in errors when handled.
![image](https://github.com/user-attachments/assets/63b874aa-4271-4986-bfc3-5fdbf1dd8c87)
